### PR TITLE
Update styles.scss

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -9,7 +9,7 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap');
 
 /* Basic typography */
-html, body {
+html, body, th, td {
   font-family: 'IBM Plex Serif', Georgia, serif;
 }
 .typeset {


### PR DESCRIPTION
Set font-family of <th> and <td> to 'IBM Plex Serif' (since https://open-econ.org/events/ incorrectly uses the default serif font).